### PR TITLE
fix: subscribe stream cannot be null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -163,10 +163,7 @@ const useOpenTok = () => {
 
   const subscribe = useCallback(
     ({ stream, element, options }) => {
-      const { streamId } = stream;
-      const pickedStream = streams.find(s => s.streamId === streamId);
-
-      const subscriber = session.subscribe(pickedStream, element, {
+      const subscriber = session.subscribe(stream, element, {
         ...defaultOptions,
         ...options,
       });
@@ -174,7 +171,7 @@ const useOpenTok = () => {
       action.addSubscriber(subscriber);
       return subscriber;
     },
-    [action, session, streams]
+    [action, session]
   );
 
   const unsubscribe = useCallback(


### PR DESCRIPTION
It no need to find in streams again to make state change.

For example, if users use `subscribe` in `useEffect` will make re-render all the time.